### PR TITLE
fix: Update repository URLs in package.json and README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,7 +504,7 @@ We welcome contributions! Please reach out on Discord for details.
 
 ```bash
 # Clone the repository
-git clone https://github.com/yourusername/creem-nextjs.git
+git clone https://github.com/armitage-labs/creem-nextjs-adaptor.git
 
 # Install dependencies
 npm install

--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/yourusername/creem-nextjs"
+    "url": "https://github.com/armitage-labs/creem-nextjs-adaptor"
   }
 }


### PR DESCRIPTION
This PR updates the repository URL in package.json

Why This Matters:

Critical for NPM Users: When developers browse this package on [npmjs.com](https://www.npmjs.com/package/@creem_io/nextjs), the repository link is one of the primary ways they:

- Access the source code
- Report issues
- Submit pull requests
- Review documentation
- Verify package authenticity and maintenance status

Without the correct repository URL, users will be directed to the wrong repository (or a 404 page), creating confusion and potentially blocking contributions or issue reports.